### PR TITLE
Add docstring for comp_type

### DIFF
--- a/wg1template/histogram_plots.py
+++ b/wg1template/histogram_plots.py
@@ -226,9 +226,10 @@ class HistogramPlot:
         :param label: Component label for the histogram.
         :param data: Data to be histogramed.
         :param weights: Weights for the events in data.
-        :param comp_type:
+        :param comp_type: ``single`` or ``stacked`` for plotting components
+            individually or stacking them on each other.
         :param histtype: Specifies the histtype of the component in the
-        histogram.
+            histogram.
         :param color: Color of the histogram component.
         :param ls: Linestyle of the histogram component.
         """


### PR DESCRIPTION
Just noticed that the docstring for comp_type was missing and quickly added some. Feel free to dismiss the PR and add your own documentation, if unhappy with the wroding. If we had python3.8, I also would have changed the type hint to the new [`typing.Literal["single", "stacked"]`](https://docs.python.org/3/library/typing.html#typing.Literal)