### PR TITLE
Align more with Belle 2 style: Error bar caps and top-right ticks disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ setup your basf2 enviroment, then run
 `pip install git+https://github.com/MarkusPrim/WG1Template.git`
 
 to install the package.
+
+## Configuration
+
+### Enable/disable errorbar caps and top-right ticks
+
+The recommendations of the [Belle2Style](https://stash.desy.de/projects/B2D/repos/belle2style) are not to have
+top/right axis ticks or errorbar caps, but some users might still prefer them. They can be enabled by
+
+```python
+from wg1template plot_style
+plot_style.set_matplotlibrc_params(errorbar_caps=True, top_right_ticks=True)
+```

--- a/wg1template/plot_style.py
+++ b/wg1template/plot_style.py
@@ -102,20 +102,23 @@ kit_color_cycler = cycler("color", KITColors.default_colors)
 tango_color_cycler = cycler("color", TangoColors.default_colors)
 
 
-def set_matplotlibrc_params():
+def set_matplotlibrc_params(
+    errorbar_caps=False,
+    top_right_ticks=False,
+):
     """
     Sets default parameters in the matplotlibrc.
     :return: None
     """
     xtick = {
-        'top': True,
+        'top': top_right_ticks,
         'minor.visible': True,
         'direction': 'in',
         'labelsize': 10
     }
 
     ytick = {
-        'right': True,
+        'right': top_right_ticks,
         'minor.visible': True,
         'direction': 'in',
         'labelsize': 10
@@ -136,7 +139,7 @@ def set_matplotlibrc_params():
         'frameon': False
     }
     errorbar = {
-        'capsize': 2
+        'capsize': 2 if errorbar_caps else 0
     }
 
     plt.rc('lines', **lines)


### PR DESCRIPTION
I did this changed to my version of the WG1 template for the ICHEP plots and I was asked by Hannah/Racha to maybe make a PR from it. I first did it for Philip Grace's fork on stash, since I though the later is the new official version of the WG1 template, but he said it's just a private for and this is still the "official" version, so I'm moving my PRs here.