### PR TITLE
Center axis labels by default as recommended in Belle2 Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,17 @@ setup your basf2 enviroment, then run
 `pip install git+https://github.com/MarkusPrim/WG1Template.git`
 
 to install the package.
+
+
+
+## Configuration
+
+### Align axis labels on the axes ends
+
+To get axis labels at the axes ends, as was the default in previous versions of the WG1 template, you just
+have to change some global variables that the WG1 template uses:
+
+```python
+wg1template.plot_style.xlabel_pos = {"x": 1, "ha": "right"}
+wg1template.plot_style.ylabel_pos = {"x": 1, "ha": "right"}
+```

--- a/wg1template/plot_style.py
+++ b/wg1template/plot_style.py
@@ -92,11 +92,9 @@ class TangoColors(object):
     ]
 
 
-# these variables can be given as arguments to matplotlib
-# set_x/y_label functions in order to align the text to
-# end of the axes
-xlabel_pos = OrderedDict([('x', 1), ('ha', 'right')])
-ylabel_pos = OrderedDict([('y', 1), ('ha', 'right')])
+# You can edit these two global variable to adjust where on the axes the labels are displayed.
+xlabel_pos = {}
+ylabel_pos = {}
 
 kit_color_cycler = cycler("color", KITColors.default_colors)
 tango_color_cycler = cycler("color", TangoColors.default_colors)


### PR DESCRIPTION
Disabling/enabling the centered axis labels sadly can't be done just by editing matplotlibrc params. I wasn't sure what's the best way to do this in a way that it's easy to switch between both, I just went for the easiest approach and made the dictionary for the position by default empty.